### PR TITLE
Api service add functionality new terms

### DIFF
--- a/MobileApp_C971_LAP2_PaulMilke/Services/RestService.cs
+++ b/MobileApp_C971_LAP2_PaulMilke/Services/RestService.cs
@@ -1,5 +1,6 @@
 ﻿using MobileApp_C971_LAP2_PaulMilke.Models;
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 
 namespace MobileApp_C971_LAP2_PaulMilke.Services
@@ -50,6 +51,24 @@ namespace MobileApp_C971_LAP2_PaulMilke.Services
                 Debug.WriteLine($"\tERROR {ex}", ex.Message);
             }
             return Terms; 
+        }
+
+        public async Task<bool> SaveNewTermAsync(Term newTerm)
+        {
+            Uri uri = new Uri($"{url}/Term");
+            string json = JsonSerializer.Serialize(newTerm);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            HttpResponseMessage response = await _httpClient.PostAsync(uri, content);
+            if (response.IsSuccessStatusCode)
+            {
+                return true; 
+            }
+            else
+            {
+                Debug.WriteLine($"Failed to add new term: {response.StatusCode}");
+                return false; 
+            }
         }
     }
 }

--- a/MobileApp_C971_LAP2_PaulMilke/Services/RestService.cs
+++ b/MobileApp_C971_LAP2_PaulMilke/Services/RestService.cs
@@ -8,8 +8,10 @@ namespace MobileApp_C971_LAP2_PaulMilke.Services
     {
         HttpClient _httpClient;
         JsonSerializerOptions _serializerOptions;
+        
 
         public List<Term> Terms { get; private set; }
+        private readonly string url = "https://10.0.2.2:7151";
 
         public RestService() 
         {
@@ -25,10 +27,11 @@ namespace MobileApp_C971_LAP2_PaulMilke.Services
             };
         }
 
+        
+
         public async Task<List<Term>> RefreshTermsAsync()
         {
             Terms = new List<Term>();
-            var url = DeviceInfo.Platform == DevicePlatform.Android ? "https://10.0.2.2:7151" : "http://localhost:5072";
             Uri uri = new Uri($"{url}/Term");
 
             try

--- a/MobileApp_C971_LAP2_PaulMilke/View Model/AddNewTermPopupViewModel.cs
+++ b/MobileApp_C971_LAP2_PaulMilke/View Model/AddNewTermPopupViewModel.cs
@@ -114,6 +114,7 @@ namespace MobileApp_C971_LAP2_PaulMilke.View_Model
                     //await _schoolDatabase.SaveTermAsync(newTerm);
                     RestService restApi = new RestService();
                     await restApi.SaveNewTermAsync(newTerm);
+                    WeakReferenceMessenger.Default.Send(new TermUpdateMessage());
                 }
 
             }

--- a/MobileApp_C971_LAP2_PaulMilke/View Model/AddNewTermPopupViewModel.cs
+++ b/MobileApp_C971_LAP2_PaulMilke/View Model/AddNewTermPopupViewModel.cs
@@ -111,7 +111,9 @@ namespace MobileApp_C971_LAP2_PaulMilke.View_Model
                 else
                 {
                     Term newTerm = new Term(titleText, startDate, endDate);
-                    await _schoolDatabase.SaveTermAsync(newTerm);
+                    //await _schoolDatabase.SaveTermAsync(newTerm);
+                    RestService restApi = new RestService();
+                    await restApi.SaveNewTermAsync(newTerm);
                 }
 
             }


### PR DESCRIPTION
Adds the ability to add a new term but via the API rather than just locally. After adding the term, the home page automatically updates to include the new term. 